### PR TITLE
per Khai, the cfn-lint is for scicomp related PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ jobs:
     - stage: validate
       script:
         - yamllint ./config ./templates
-        - ./lint_stack.sh -l ./config/prod || travis_terminate 1
         - cfn-lint ./templates/**/*
     - stage: deploy
       script:
-        - ./lint_stack.sh -r || travis_terminate 1
         - travis_wait 30 sceptre launch $TRAVIS_BRANCH --yes


### PR DESCRIPTION
They have a model of one resource per PR, and this large merge is putting multiple resources in at once.