### PR TITLE
Use latest docker tag instead of version

### DIFF
--- a/config/prod/base.yaml
+++ b/config/prod/base.yaml
@@ -2,7 +2,7 @@
 template_path: base.yaml
 stack_name: bsmnmanifests
 parameters:
-  MainContainer: bsmnetwork/ndasynapse-manifests:v3.0.0
+  MainContainer: bsmnetwork/ndasynapse-manifests:latest
   Department: "SysBio"
   Project: "bsmn"
   OwnerEmail: "kenneth.daily@sagebase.org"


### PR DESCRIPTION
It's an extra step of deployment to bump the version of the image used. In this case, the image is fairly stable, and risk is low to use latest.